### PR TITLE
Added support for poster URLs and Error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielpadmore/movie-client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.js",
   "repository": "git@github.com:danielpadmore/movie-client.git",
   "publishConfig": {

--- a/src/models/movie-db/movie-search-result.ts
+++ b/src/models/movie-db/movie-search-result.ts
@@ -20,4 +20,5 @@ export interface MovieDBSearchResults {
   total_results: number;
   total_pages: number;
   results: MovieSearchResult[];
+  status_message?: string;
 }

--- a/src/movie-db-client.ts
+++ b/src/movie-db-client.ts
@@ -20,8 +20,13 @@ export default class MovieDBClient implements MovieClient {
       headers: this.defaultHeaders
     });
     const response: MovieDBSearchResults = await request.json();
-    const movies = parseMovieSearchResults(response);
-    return movies;
+    if (request.status === 200) {
+      return parseMovieSearchResults(response);
+    } else if (response.status_message) {
+      throw { message: response.status_message };
+    } else {
+      throw { message: "Unexpected error" };
+    }
   }
 }
 
@@ -39,8 +44,12 @@ export function parseMovieSearchResults(
   return searchResults.results.map(
     (result): Movie => ({
       id: result.id,
-      posterUrl: result.poster_path,
-      backdropUrl: result.backdrop_path,
+      posterUrl: result.poster_path
+        ? "https://image.tmdb.org/t/p/w500/" + result.poster_path
+        : "",
+      backdropUrl: result.backdrop_path
+        ? "https://image.tmdb.org/t/p/w500/" + result.backdrop_path
+        : "",
       popularity: result.popularity,
       voteCount: result.vote_count,
       adult: result.adult,


### PR DESCRIPTION
Disclaimer - there is a configuration endpoint which the client would have to request from to build the image URL correctly (the base of which may change over time). For the time being i've added a static version of this base url.